### PR TITLE
In the class SQLiteDatabase, add inTransaction() method to check if the ...

### DIFF
--- a/src/main/java/org/sqldroid/SQLDroidConnection.java
+++ b/src/main/java/org/sqldroid/SQLDroidConnection.java
@@ -388,9 +388,11 @@ public class SQLDroidConnection implements Connection {
         }
         this.autoCommit = autoCommit;
         if (autoCommit) {
-            sqlitedb.setTransactionSuccessful();
-            Log.d("END TRANSACTION (autocommit on) " + Thread.currentThread().getId() + " \"" + Thread.currentThread().getName() + "\" " + this);
-            sqlitedb.endTransaction();
+            if (sqlitedb.inTransaction()) { // to be on safe side.
+                sqlitedb.setTransactionSuccessful();
+                Log.d("END TRANSACTION (autocommit on) " + Thread.currentThread().getId() + " \"" + Thread.currentThread().getName() + "\" " + this);
+                sqlitedb.endTransaction();
+            }
         } else {
             Log.d("BEGIN TRANSACTION (autocommit off) " + Thread.currentThread().getId() + " \"" + Thread.currentThread().getName() + "\" " + this);
             sqlitedb.beginTransaction();

--- a/src/main/java/org/sqldroid/SQLiteDatabase.java
+++ b/src/main/java/org/sqldroid/SQLiteDatabase.java
@@ -180,6 +180,13 @@ public class SQLiteDatabase {
   public android.database.sqlite.SQLiteDatabase getSqliteDatabase() {
     return sqliteDatabase;
   }
+  
+ /** Checks if the current thread has a transaction pending in the database.
+   * @return true if the current thread has a transaction pending in the database
+   */
+  public boolean inTransaction() {
+      return sqliteDatabase.inTransaction();
+  }
 
   /** Executes one of the methods in the "transactions" enum. This just allows the
    * timeout code to be combined in one method. 


### PR DESCRIPTION
...current thread has a transaction pending in the database. In the class SQLDroidConnection, modify the setAutoCommit() to invoke endTransaction() only after checking that inTransaction() is true.  This safe practice is to avoid some intermittent 'database locked' behavior observed from the android.database.sqlite.SQLiteDatabase class in some versions of Android SDK.