### PR TITLE
Cannot perform this operation because the connection pool has been closed

### DIFF
--- a/src/main/java/org/sqldroid/SQLDroidConnection.java
+++ b/src/main/java/org/sqldroid/SQLDroidConnection.java
@@ -130,8 +130,8 @@ public class SQLDroidConnection implements Connection {
                 Log.i("SQLDroidConnection: " + Thread.currentThread().getId() + " \"" + Thread.currentThread().getName() + "\" " + this + " Opening new database: " + dbQname);
                 sqlitedb = new SQLiteDatabase(dbQname, timeout, retryInterval, flags);
                 dbMap.put(dbQname, sqlitedb);
-                clientMap.put(this, sqlitedb);
             }
+            clientMap.put(this, sqlitedb);
         }
     }
 

--- a/src/main/java/org/sqldroid/SQLDroidPreparedStatement.java
+++ b/src/main/java/org/sqldroid/SQLDroidPreparedStatement.java
@@ -1,7 +1,6 @@
 package org.sqldroid;
 
 import android.database.Cursor;
-import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -64,7 +63,7 @@ public class SQLDroidPreparedStatement implements PreparedStatement {
   public int updateCount = -1;
 
   public SQLDroidPreparedStatement(String sql, SQLDroidConnection sqldroid) {
-    Log.v("SQLDRoid", "new SqlDRoid prepared statement from " + sqldroid);
+    Log.v("new SqlDRoid prepared statement from " + sqldroid);
     this.sqldroidConnection = sqldroid;
     this.db = sqldroid.getDb();
     setSQL(sql);


### PR DESCRIPTION
Having concurrent connections to the same SQLite database I was experiencing the following errors:

- "Cannot perform this operation because the connection pool has been closed."
- "attempt to re-open an already-closed object"

Using commit https://github.com/SQLDroid/SQLDroid/commit/4666757512f8019ad1f11eed3c5d5c16c7bb7297 in the pull request the problems are gone.
When you review the pull request the error fixed should be obvious. If not just ask :-)