### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/main/java/org/sqldroid/DroidDataSource.java
+++ b/src/main/java/org/sqldroid/DroidDataSource.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
 import javax.sql.DataSource;
 
 public class DroidDataSource implements DataSource {
-    Connection connection = null;    
+    private Connection connection = null;
     protected String description = "Android Sqlite Data Source";
     protected String packageName;
     protected String databaseName;  

--- a/src/main/java/org/sqldroid/SQLDroidBlob.java
+++ b/src/main/java/org/sqldroid/SQLDroidBlob.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class SQLDroidBlob implements Blob {
 
-	byte [] b;
+	private byte [] b;
 	
 	public SQLDroidBlob(byte [] b) {
 		this.b = b;

--- a/src/main/java/org/sqldroid/SQLDroidClob.java
+++ b/src/main/java/org/sqldroid/SQLDroidClob.java
@@ -43,7 +43,7 @@ public class SQLDroidClob implements Clob
     private InputStream inputStream;
 
     /** Whether we have already freed resources. */
-    boolean freed = false;
+    private boolean freed = false;
 
     /**
      * Constructor taking a string.

--- a/src/main/java/org/sqldroid/SQLDroidDatabaseMetaData.java
+++ b/src/main/java/org/sqldroid/SQLDroidDatabaseMetaData.java
@@ -34,7 +34,7 @@ public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 	getBestRowIdentifier  = null,   getVersionColumns    = null,
 	getColumnPrivileges   = null;
 	
-	SQLDroidConnection con;
+	private SQLDroidConnection con;
     
 	public SQLDroidDatabaseMetaData(SQLDroidConnection con) {
 		this.con = con;
@@ -1606,13 +1606,13 @@ public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 	 */
 	class PrimaryKeyFinder {
 		/** The table name. */
-		String table;
+		private String table;
 
 		/** The primary key name. */
-		String pkName = null;
+		private String pkName = null;
 
 		/** The column(s) for the primary key. */
-		String pkColumns[] = null;
+		private String pkColumns[] = null;
 
 		/**
 		 * Constructor.

--- a/src/main/java/org/sqldroid/SQLDroidSQLException.java
+++ b/src/main/java/org/sqldroid/SQLDroidSQLException.java
@@ -11,7 +11,7 @@ public class SQLDroidSQLException extends java.sql.SQLException {
   private static final long serialVersionUID = -7299376329007161001L;
 
   /** The exception that this exception was created for. */
-  SQLException sqlException;
+  private SQLException sqlException;
   
   /** Create a hard java.sql.SQLException from the RuntimeException android.database.SQLException. */ 
   public SQLDroidSQLException (SQLException sqlException) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat