### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/org/sqldroid/SQLDroidDatabaseMetaData.java
+++ b/src/main/java/org/sqldroid/SQLDroidDatabaseMetaData.java
@@ -22,6 +22,7 @@ import android.database.MergeCursor;
 
 public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 
+	private final static Map<String, Integer> RULE_MAP = new HashMap<String, Integer>();
 	private static final int SQLITE_DONE       =  101;
 	private static final String VIEW_TYPE = "VIEW";
 	private static final String TABLE_TYPE = "TABLE";
@@ -35,7 +36,25 @@ public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 	getColumnPrivileges   = null;
 	
 	SQLDroidConnection con;
-    
+
+	/**
+	 * Pattern used to extract a named primary key.
+	 */
+	protected final static Pattern FK_NAMED_PATTERN =
+			Pattern.compile(".* constraint +(.*?) +foreign +key *\\((.*?)\\).*", Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * Pattern used to extract column order for an unnamed primary key.
+	 */
+	protected final static Pattern PK_UNNAMED_PATTERN =
+			Pattern.compile(".* primary +key *\\((.*?,+.*?)\\).*", Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * Pattern used to extract a named primary key.
+	 */
+	protected final static Pattern PK_NAMED_PATTERN =
+			Pattern.compile(".* constraint +(.*?) +primary +key *\\((.*?)\\).*", Pattern.CASE_INSENSITIVE);
+
 	public SQLDroidDatabaseMetaData(SQLDroidConnection con) {
 		this.con = con;
 	}
@@ -344,8 +363,6 @@ public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 		return "0.0.1 alpha";
 	}
 
-	private final static Map<String, Integer> RULE_MAP = new HashMap<String, Integer>();
-
 	static {
 		RULE_MAP.put("NO ACTION", importedKeyNoAction);
 		RULE_MAP.put("CASCADE", importedKeyCascade);
@@ -354,25 +371,6 @@ public class SQLDroidDatabaseMetaData implements DatabaseMetaData {
 		RULE_MAP.put("SET DEFAULT", importedKeySetDefault);
 	}
 
-	/**
-	 * Pattern used to extract a named primary key.
-	 */
-	protected final static Pattern FK_NAMED_PATTERN =
-			Pattern.compile(".* constraint +(.*?) +foreign +key *\\((.*?)\\).*", Pattern.CASE_INSENSITIVE);
-
-	/**
-	 * Pattern used to extract column order for an unnamed primary key.
-	 */
-	protected final static Pattern PK_UNNAMED_PATTERN =
-			Pattern.compile(".* primary +key *\\((.*?,+.*?)\\).*", Pattern.CASE_INSENSITIVE);
-
-	/**
-	 * Pattern used to extract a named primary key.
-	 */
-	protected final static Pattern PK_NAMED_PATTERN =
-			Pattern.compile(".* constraint +(.*?) +primary +key *\\((.*?)\\).*", Pattern.CASE_INSENSITIVE);
-
-	
 	@Override
 	public ResultSet getExportedKeys(String catalog, String schema, String table)
 			throws SQLException {

--- a/src/main/java/org/sqldroid/SQLiteDatabase.java
+++ b/src/main/java/org/sqldroid/SQLiteDatabase.java
@@ -56,21 +56,7 @@ public class SQLiteDatabase {
   /** The method to invoke to get the changed row count. */
   protected Method getChangedRowCount;
 
-  /** Returns true if the exception is an instance of "SQLiteDatabaseLockedException".  Since this exception does not exist
-   * in APIs below 11 this code uses reflection to check the exception type. 
-   */
-  protected boolean isLockedException ( SQLiteException maybeLocked ) {
-    try {
-      if (Class.forName("android.database.sqlite.SQLiteDatabaseLockedException", false, getClass().getClassLoader()).isAssignableFrom(maybeLocked.getClass()) ) {
-        return true;
-      }
-    } catch (ClassNotFoundException e) {
-      // no android.database.sqlite.SQLiteDatabaseLockedException
-    }
-    return false;
-  }
-
-  /** 
+  /**
    * @param dbQname
    * @param timeout
    * @param retryInterval
@@ -103,6 +89,20 @@ public class SQLiteDatabase {
         }
       }
     }
+  }
+
+  /** Returns true if the exception is an instance of "SQLiteDatabaseLockedException".  Since this exception does not exist
+   * in APIs below 11 this code uses reflection to check the exception type.
+   */
+  protected boolean isLockedException ( SQLiteException maybeLocked ) {
+    try {
+      if (Class.forName("android.database.sqlite.SQLiteDatabaseLockedException", false, getClass().getClassLoader()).isAssignableFrom(maybeLocked.getClass()) ) {
+        return true;
+      }
+    } catch (ClassNotFoundException e) {
+      // no android.database.sqlite.SQLiteDatabaseLockedException
+    }
+    return false;
   }
 
   /** Proxy for the "rawQuery" command. 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat