### PR TITLE
Fix #33 ResultSet.getTimestamp is off by -12 hours between 12:00-13:00

### DIFF
--- a/src/main/java/org/sqldroid/SQLDroidResultSet.java
+++ b/src/main/java/org/sqldroid/SQLDroidResultSet.java
@@ -13,6 +13,8 @@ import java.util.Calendar;
 import java.util.Map;
 
 public class SQLDroidResultSet implements ResultSet {
+    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
     public static boolean dump = false;
 
     private final Cursor c;
@@ -564,7 +566,7 @@ public class SQLDroidResultSet implements ResultSet {
         default:
           // format 2011-07-11 11:36:30.009
           try {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            SimpleDateFormat dateFormat = new SimpleDateFormat(TIMESTAMP_FORMAT);
             java.util.Date parsedDate = dateFormat.parse(getString(index));
             timestamp = new Timestamp(parsedDate.getTime());
           } catch ( Exception any ) {

--- a/src/main/java/org/sqldroid/SQLDroidResultSet.java
+++ b/src/main/java/org/sqldroid/SQLDroidResultSet.java
@@ -564,7 +564,7 @@ public class SQLDroidResultSet implements ResultSet {
         default:
           // format 2011-07-11 11:36:30.009
           try {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.S");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
             java.util.Date parsedDate = dateFormat.parse(getString(index));
             timestamp = new Timestamp(parsedDate.getTime());
           } catch ( Exception any ) {


### PR DESCRIPTION
NB: This is a really critical bug! SQLDroid currently reads some timestamps (between 12:00:00-12:59:59) with the wrong value! This is silently wrongful behavior that causes mysterious bugs.

We got this bug reported to us as "some of the times in the database looks like they are wrong." This is a really hard issue to debug, as we had no idea where the error occurred and didn't initially suspect SQLDroid (or any third party library).