### PR TITLE
Make setEscapeProcessing only throw when true

### DIFF
--- a/src/main/java/org/sqldroid/SQLDroidStatement.java
+++ b/src/main/java/org/sqldroid/SQLDroidStatement.java
@@ -265,7 +265,7 @@ public class SQLDroidStatement implements Statement {
 
   @Override
   public void setEscapeProcessing(boolean enable) throws SQLException {
-    if (!enable) {
+    if (enable) {
       throw new UnsupportedOperationException("setEscapeProcessing not implemented yet");
     }
   }


### PR DESCRIPTION
This has broken Flyway's Android integration for quite some time (see https://github.com/SQLDroid/SQLDroid/issues/76#issuecomment-479070178).

I don't see why this should throw if you provide `false`. This change is consistent with [Xerial's behavior]( https://github.com/xerial/sqlite-jdbc/blob/master/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java#L380).